### PR TITLE
removed --force from 'latest' cron (redundant, may be causing issues)

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -282,7 +282,7 @@ metacpan::crons::api:
     # 21:09 < oalders> 02packages gets updated more frequently now, but i'm not sure if
     # it's in real time.  i thought it was every 5 minutes
     latest:
-        cmd : 'latest --force >/var/log/starman/metacpan-api/latest.log 2>&1'
+        cmd : 'latest >/var/log/starman/metacpan-api/latest.log 2>&1'
         minute : 30
         ensure : absent
     backup_favorite:


### PR DESCRIPTION
I suspect this causes a temporary loss of status='latest' for some releases.
Let's remove it (it was just there to fix another issue anyway) and properly debug any problems if occur.