### PR TITLE
SSH Hardening

### DIFF
--- a/modules/metacpan/files/default/etc/ssh/sshd_config
+++ b/modules/metacpan/files/default/etc/ssh/sshd_config
@@ -23,9 +23,9 @@ SyslogFacility AUTH
 LogLevel INFO
 
 # Authentication:
-LoginGraceTime 120
-MaxAuthTries 1                   # With key auth, we shouldn't need the password prompt.
-PermitRootLogin without-password # Allows root with public keys, but no root with passwords
+LoginGraceTime 30   # Default 120 - Using pubkeys, we don't need long prompts
+MaxAuthTries 1      # Default 6 - Using pubkeys, one is sufficient
+PermitRootLogin no  # Disallow root logins
 StrictModes yes
 
 RSAAuthentication yes
@@ -87,8 +87,6 @@ Subsystem sftp /usr/lib/openssh/sftp-server
 # and ChallengeResponseAuthentication to 'no'.
 UsePAM yes
 
-# Allow root to login
-AllowUsers root
 # Only members of the shell access are allowed to attempt authentication.
 AllowGroups shellaccess
-# The default policy when using AllowGroups and AllowUsers is a Deny
+# When AllowGroups is stated, a default DENY policy is applied.

--- a/modules/metacpan/files/default/etc/ssh/sshd_config
+++ b/modules/metacpan/files/default/etc/ssh/sshd_config
@@ -1,0 +1,94 @@
+# Package generated configuration file
+# See the sshd_config(5) manpage for details
+
+# What ports, IPs and protocols we listen for
+Port 22
+# Use these options to restrict which interfaces/protocols sshd will bind to
+#ListenAddress ::
+#ListenAddress 0.0.0.0
+Protocol 2
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+#Privilege Separation is turned on for security
+UsePrivilegeSeparation yes
+
+# Lifetime and size of ephemeral version 1 server key
+KeyRegenerationInterval 3600
+ServerKeyBits 768
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+LoginGraceTime 120
+MaxAuthTries 1                   # With key auth, we shouldn't need the password prompt.
+PermitRootLogin without-password # Allows root with public keys, but no root with passwords
+StrictModes yes
+
+RSAAuthentication yes
+PubkeyAuthentication yes
+#AuthorizedKeysFile	%h/.ssh/authorized_keys
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# For this to work you will also need host keys in /etc/ssh_known_hosts
+RhostsRSAAuthentication no
+# similar for protocol version 2
+HostbasedAuthentication no
+# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Change to no to disable tunnelled clear text passwords
+#PasswordAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosGetAFSToken no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+X11Forwarding yes
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+#UseLogin no
+
+#MaxStartups 10:30:60
+#Banner /etc/issue.net
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+# Allow root to login
+AllowUsers root
+# Only members of the shell access are allowed to attempt authentication.
+AllowGroups shellaccess
+# The default policy when using AllowGroups and AllowUsers is a Deny

--- a/modules/metacpan/manifests/init.pp
+++ b/modules/metacpan/manifests/init.pp
@@ -77,6 +77,11 @@ class metacpan(
     $api_crons = hiera_hash('metacpan::crons::api', {})
     create_resources('metacpan::cron::api', $api_crons)
 
+    group {
+      'shellaccess':
+        ensure => present;
+    }
+
     file { $tmp_dir:
       ensure => directory,
       owner  => $user,

--- a/modules/metacpan/manifests/system/ssh.pp
+++ b/modules/metacpan/manifests/system/ssh.pp
@@ -2,6 +2,14 @@ class metacpan::system::ssh {
   package { ["openssh-server", "openssh-client"]:
     ensure => latest,
   }->
+  file {
+    "/etc/ssh/sshd_config":
+      source => "puppet:///modules/metacpan/default/etc/ssh/sshd_config",
+      mode   => 0444,
+      owner  => root,
+      group  => root,
+      notify => Service['ssh'];
+  }->
   service { ssh:
     ensure => running,
   }

--- a/modules/metacpan/manifests/user.pp
+++ b/modules/metacpan/manifests/user.pp
@@ -21,6 +21,7 @@ define metacpan::user(
           comment    => "$fullname",
           shell      => "$shell",
           provider   => "useradd",
+          groups     => [ "shellaccess" ],
       }->
       file {
         "$path/$user":


### PR DESCRIPTION
Disable SSH access for everyone not in the designated group.  Disable root SSH access.  Restrict the number of auth tries allowed before tearing down the SSH connection.