### PR TITLE
Enable the eris dispatcher

### DIFF
--- a/hieradata/nodes/bm-mc-03.yaml
+++ b/hieradata/nodes/bm-mc-03.yaml
@@ -20,3 +20,6 @@ metacpan::fw_ports:
 metacpan::web::starman:
   metacpan-web:
     git_revision: 'stage'
+
+rsyslog::extra_modules:
+    - "omprog"

--- a/modules/metacpan/manifests/system/rsyslog/server.pp
+++ b/modules/metacpan/manifests/system/rsyslog/server.pp
@@ -22,5 +22,21 @@ class metacpan::system::rsyslog::server(
     rotate                    => undef
   }
 
+  # Grab the Perl version in use
+  $perl_version = hiera('perl::version', '5.22.2')
+
+  # Perl Modules for the eris logging system
+  perl::module {
+    [
+      'eris', 'POE::Component::Client::eris', 'POE::Component::Server::eris'
+    ]:
+  }
+
+  # Enable the dispatcher
+  rsyslog::snippet {
+    'eris-dispatcher':
+      content => "\$ActionOMProgBinary /opt/perl-$perl_version/bin/eris-dispatcher-stdin.pl\n*.* :omprog:\n",
+      require => Perl::Module["POE::Component::Server::eris"];
+  }
 }
 


### PR DESCRIPTION
Install the requisite Perl modules and enable the omprog output for the
rsyslog server role to send all incoming data through the dispatcher.