### PR TITLE
Run permission/package scripts in cleanup mode once an hour

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -352,8 +352,9 @@ metacpan::crons::api:
     package:
         cmd : package
         minute : '*/10'
-        hour: ['1-23']
+        hour: '1-23'
         ensure : absent
+    # Run the full package cleanup - can take half an hour
     package_cleanup:
         cmd : 'package --clean_up'
         minute : 0
@@ -362,8 +363,9 @@ metacpan::crons::api:
     permission:
         cmd : permission
         minute : '*/10'
-        hour: ['1-23']
+        hour: '1-23'
         ensure : absent
+    # Run the full permissions cleanup - can take half an hour
     permission_cleanup:
         cmd : 'permission --clean_up'
         minute : 0

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -352,10 +352,22 @@ metacpan::crons::api:
     package:
         cmd : package
         minute : '*/10'
+        hour: ['1-23']
+        ensure : absent
+    package_cleanup:
+        cmd : 'package --clean_up'
+        minute : 0
+        hour: 0
         ensure : absent
     permission:
         cmd : permission
         minute : '*/10'
+        hour: ['1-23']
+        ensure : absent
+    permission_cleanup:
+        cmd : 'permission --clean_up'
+        minute : 0
+        hour: 0
         ensure : absent
     tickets:
         cmd : tickets

--- a/hieradata/nodes/lw-mc-03.yaml
+++ b/hieradata/nodes/lw-mc-03.yaml
@@ -53,7 +53,11 @@ metacpan::crons::api:
       ensure : present
     package:
       ensure : present
+    package_cleanup:
+      ensure : present
     permission:
+      ensure : present
+    permission_cleanup:
       ensure : present
     tickets:
       ensure : present


### PR DESCRIPTION
block `permission` & `package` scripts for an hour a day and run a single instance of them in cleanup mode during that time (longer run, deletes removed entries).