### PR TITLE
Fix the rsyslog module

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -442,3 +442,8 @@ nginx::allowed:
   - 203.57.145.12/32
   - 23.235.32.0/20
   - 43.249.72.0/22
+# Disable the systemd imjournal
+rsyslog::im_journal_ratelimit_interval: false
+rsyslog::im_journal_statefile: false
+rsyslog::im_journal_ratelimit_burst: false
+rsyslog::im_journal_ignore_previous_messages: false

--- a/modules/metacpan/templates/rsyslog/server-metacpan.conf.erb
+++ b/modules/metacpan/templates/rsyslog/server-metacpan.conf.erb
@@ -39,7 +39,8 @@ $Template dynAllMessages,"<%= scope.lookupvar('rsyslog::server::server_dir') -%>
 
 # Send to the eris system
 $ActionOMProgBinary /usr/local/sbin/rsyslog-eris-bridge
-*.*  :omprog:;RSYSLOG_ForwardFormat
+$template RFC3164fmt,"<%= '<%PRI%' + '>%TIMESTAMP% %HOSTNAME% %syslogtag%%msg%' %>\n"
+*.*  :omprog:;RFC3164fmt
 
 <% # Common footer across all templates -%>
 <%= scope.function_template(['rsyslog/server/_default-footer.conf.erb']) %>


### PR DESCRIPTION
Disable the imjournal settings incorrectly ending up in the
rsyslog.conf.  Explicitly send the newline on each omprog line.