### PR TITLE
Added a cronjob for cover data filling

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -422,6 +422,11 @@ metacpan::crons::api:
         minute: 0
         weekday: 0
         ensure : absent
+    cover_full:
+        cmd : 'cover'
+        hour: 14
+        minute: 0
+        ensure : absent
 
 metacpan::fw_ports:
   http:

--- a/hieradata/nodes/lw-mc-03.yaml
+++ b/hieradata/nodes/lw-mc-03.yaml
@@ -79,3 +79,5 @@ metacpan::crons::api:
       ensure : present
     favorite_weekly:
       ensure : present
+    cover_full:
+      ensure : present


### PR DESCRIPTION
This cron will run daily for now (takes about an hour for the
full data set), until we set a system for smaller incremental
data sets on the cpancover end.