### PR TITLE
make puppet quiet about validations that use old syntax

### DIFF
--- a/modules/munin/manifests/node.pp
+++ b/modules/munin/manifests/node.pp
@@ -62,20 +62,20 @@ class munin::node (
   $file_group     = $munin::params::node::file_group,
 ) inherits munin::params::node {
 
-  validate_array($allow)
-  validate_array($nodeconfig)
-  validate_array($masterconfig)
-  validate_string($mastergroup)
-  validate_string($mastername)
-  validate_hash($plugins)
-  validate_string($address)
-  validate_absolute_path($config_root)
-  validate_string($package_name)
-  validate_string($service_name)
-  validate_re($service_ensure, '^(|running|stopped)$')
-  validate_re($export_node, '^(enabled|disabled)$')
-  validate_absolute_path($log_dir)
-  validate_string($file_group)
+  # validate_array($allow)
+  # validate_array($nodeconfig)
+  # validate_array($masterconfig)
+  # validate_string($mastergroup)
+  # validate_string($mastername)
+  # validate_hash($plugins)
+  # validate_string($address)
+  # validate_absolute_path($config_root)
+  # validate_string($package_name)
+  # validate_string($service_name)
+  # validate_re($service_ensure, '^(|running|stopped)$')
+  # validate_re($export_node, '^(enabled|disabled)$')
+  # validate_absolute_path($log_dir)
+  # validate_string($file_group)
 
   if $mastergroup {
     $fqn = "${mastergroup};${host_name}"

--- a/modules/munin/manifests/plugin.pp
+++ b/modules/munin/manifests/plugin.pp
@@ -20,7 +20,7 @@ define munin::plugin (
     include munin::node
 
     $plugin_share_dir=$munin::node::plugin_share_dir
-    validate_absolute_path($plugin_share_dir)
+    # validate_absolute_path($plugin_share_dir)
 
     File {
         require => Package[$munin::node::package_name],
@@ -35,6 +35,7 @@ define munin::plugin (
         absent: {
             $handle_plugin = true
             $plugin_ensure = absent
+            $plugin_target = "notlink"
         }
         link: {
             $handle_plugin = true


### PR DESCRIPTION
Only warnings left should be:

```
Warning: ModuleLoader: module 'java' has unresolved dependencies - it will only see those that are resolved. Use 'puppet module list --tree' to see information about modules
   (file & line not available)
Warning: This method is deprecated, please use match expressions with Stdlib::Compat::Array instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions. at ["/etc/puppet/contrib-modules/elasticsearch/manifests/instance.pp", 260]:
   (at /etc/puppet/contrib-modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')
```

I think both are elasticsearch related but I'm going to go back to thinking about the datacenter switch over for now