### PR TITLE
Add OSSEC HIDS to the MetaCPAN Fleet

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -463,3 +463,26 @@ rsyslog::im_journal_ratelimit_interval: false
 rsyslog::im_journal_statefile: false
 rsyslog::im_journal_ratelimit_burst: false
 rsyslog::im_journal_ignore_previous_messages: false
+
+# OSSEC Configurations
+ossec::email_alert_level: 9
+ossec::email_notification: no
+ossec::email_to: security@metacpan.org
+ossec::email_from: ossec@metacpan.org
+ossec::ip_whitelist:
+  - 5.153.225.19 # bm-mc-01
+  - 5.153.225.20 # bm-mc-02
+  - 46.43.35.68  # bm-mc-03
+  - 50.28.18.102 # lw-mc-01
+  - 50.28.18.103 # lw-mc-02
+  - 50.28.18.168 # lw-mc-03
+ossec::logfiles:
+  - /var/log/auth.log
+  - /var/log/daemon.log
+  - /var/log/dpkg.log
+  - /var/log/kern.log
+ossec::role: agent
+ossec::smtp_server: 127.0.0.1
+ossec::server_ip: 127.0.0.1
+ossec::zeromq_output: no
+ossec::zeromq_uri: tcp://127.0.0.1:9514/

--- a/hieradata/env/dev.yaml
+++ b/hieradata/env/dev.yaml
@@ -14,3 +14,6 @@ metacpan::elasticsearch::master_nodes: 1
 metacpan::elasticsearch::expected_nodes: 1
 metacpan::elasticsearch::recover_after_nodes: 1
 metacpan::elasticsearch::replicas: 0
+
+# OSSEC Settings
+ossec::role: server

--- a/hieradata/env/production.yaml
+++ b/hieradata/env/production.yaml
@@ -137,3 +137,6 @@ metacpan::users:
         admin    : true
         fullname : "Joel Berger <joel.a.berger@gmail.com>"
 
+# OSSEC Configuration
+ossec::email_notification: yes
+ossec::server_ip: 46.43.35.68

--- a/hieradata/nodes/bm-mc-03.yaml
+++ b/hieradata/nodes/bm-mc-03.yaml
@@ -36,3 +36,4 @@ metacpan::crons::general:
 #   metacpan-web:
 #     git_revision: 'stage'
 
+ossec::role: server

--- a/modules/metacpan/manifests/system.pp
+++ b/modules/metacpan/manifests/system.pp
@@ -26,5 +26,6 @@ class metacpan::system(
 
   include metacpan::system::rsyslog::certs
   #include metacpan::system::rsyslog::client
+  include ossec
 
 }

--- a/modules/ossec/files/local_rules.xml
+++ b/modules/ossec/files/local_rules.xml
@@ -1,0 +1,12 @@
+<!--
+    MetaCPAN Local OSSEC Rules
+-->
+
+<group name="local,syslog,">
+	<rule id="100001" level="0">
+		<if_sid>5711</if_sid>
+		<srcip>1.1.1.1</srcip>
+		<description>Example of rule that will ignore sshd </description>
+		<description>failed logins from IP 1.1.1.1.</description>
+	</rule>
+</group>

--- a/modules/ossec/files/overwrite_rules.xml
+++ b/modules/ossec/files/overwrite_rules.xml
@@ -1,0 +1,15 @@
+<!-- Overwrite Certain Rules for Less Emails -->
+<var name="BAD_WORDS">core_dumped|failure|error|attack|bad |illegal |denied|refused|unauthorized|fatal|failed|Segmentation Fault|Corrupted</var>
+
+<group name="syslog,errors,">
+    <rule id="1002" level="2" overwrite="yes">
+        <match>$BAD_WORDS</match>
+        <options>no_email_alert</options>
+        <description>Unknown problem somewhere in the system.</description>
+    </rule>
+
+    <rule id="1003" level="13" maxsize="1025" overwrite="yes">
+        <options>no_email_alert</options>
+        <description>Non standard syslog message (size too large).</description>
+    </rule>
+</group>

--- a/modules/ossec/manifests/firewall.pp
+++ b/modules/ossec/manifests/firewall.pp
@@ -1,0 +1,33 @@
+class ossec::firewall (
+  $role = hiera("ossec::role", "agent"),
+) {
+  if( $role == "server" ) {
+    $ip_whitelist = hiera_array("ossec::ip_whitelist",[]);
+    $ip_whitelist.each |$source| {
+			firewall{ "400 OSSEC ${source} - ${name}":
+				ensure  => present,
+				dport   => [ 1514 ],
+				proto   => udp,
+				action  => 'accept',
+				source  => "${source}/32",
+			}
+			firewall{ "410 OSSEC Authentication ${source} - ${name}":
+				ensure  => present,
+				dport   => [ 1515 ],
+				proto   => tcp,
+				action  => 'accept',
+				source  => "${source}/32",
+			}
+		}
+  }
+  else {
+    $ossec_server = hiera("ossec::server_ip","127.0.0.1");
+		firewall{ "400 OSSEC ${source} - ${name}":
+			ensure  => present,
+			dport   => [ 1514 ],
+			proto   => udp,
+			action  => 'accept',
+			source  => "${ossec_server}/32",
+		}
+  }
+}

--- a/modules/ossec/manifests/init.pp
+++ b/modules/ossec/manifests/init.pp
@@ -1,0 +1,96 @@
+class ossec(
+  $role               = hiera('ossec::role'),
+  $server_ip          = hiera('ossec::server_ip'),
+  $email_alert_level  = hiera('ossec::email_alert_level'),
+  $email_from         = hiera('ossec::email_from'),
+  $email_to           = hiera('ossec::email_to'),
+  $email_notification = hiera('ossec::email_notification'),
+  $ip_whitelist       = hiera_array('ossec::ip_whitelist',[]),
+  $logfiles           = hiera_array('ossec::logfiles',[]),
+  $smtp_server        = heira('ossec::smtp_server'),
+  $zeromq_output      = heira('ossec::zeromq_output'),
+  $zeromq_uri         = heira('ossec::zeromq_uri'),
+) {
+  # Apt Source
+  apt::source {
+    'atomic':
+      location => 'https://updates.atomicorp.com/channels/ossec/debian/',
+      comment  => 'Atomic Rocket Turtle Open Source Repository',
+      repos    => 'main',
+      include  => {
+        'src' => false,
+        'deb' => true,
+      },
+      # TODO: Fix, key is borked
+      #key      =>  {
+      #  'id'     => 'FFBD5D0A4520AFA9',
+      #  'source' => "https://updates.atomicorp.com/channels/ossec/debian/dists/${$facts['lsbdistcodename']}/Release.gpg"
+      #},
+  }
+
+  # Install the Package
+  $package = "ossec-hids-$role"
+  package {
+    "$package":
+      ensure  => latest,
+      require => Apt::Source['atomic'];
+  }
+
+  # Config file
+  file {
+    '/var/ossec/etc/ossec.conf':
+      owner   => 'root',
+      group   => 'ossec',
+      content => template("ossec/$role.conf.erb"),
+      notify  => Service['ossec'],
+      require => Package["$package"];
+  }
+
+  if( $role == "server" ) {
+    # Server Specific Configs
+    file {
+      '/var/ossec/rules/local_rules.xml':
+        source  => 'puppet:///modules/ossec/local_rules.xml',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0444',
+        notify  => Service['ossec'],
+        require => Package["$package"];
+			'/var/ossec/rules/overwrite_rules.xml':
+        source  => 'puppet:///modules/ossec/overwrite_rules.xml',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0444',
+        notify  => Service['ossec'],
+        require => Package["$package"];
+    }
+    service {
+      "ossec-authd":
+        ensure => 'running',
+        enable => true,
+    }
+  }
+  else {
+    # Clients configuration
+    exec {
+      # Create a key
+      "ossec-client-auth":
+        command => "/var/ossec/bin/agent-auth -m $server_ip",
+        creates => '/var/ossec/etc/client.keys',
+        notify => Service["ossec"];
+    }
+  }
+
+  ## Setup the Firewall
+  class {
+    "ossec::firewall":
+      role => $role;
+  }
+
+  ## Start/Run the Service
+  service {
+    'ossec':
+      ensure => 'running',
+      enable =>  true,
+  }
+}

--- a/modules/ossec/templates/agent.conf.erb
+++ b/modules/ossec/templates/agent.conf.erb
@@ -1,0 +1,96 @@
+<!-- MetaCPAN OSSEC Config -->
+<ossec_config>
+  <client>
+    <server-ip><%= @server_ip %></server-ip>
+  </client>
+
+  <syscheck>
+    <!-- Syscheck Configuration -->
+    <frequency>72000</frequency>
+    <scan_on_start>no</scan_on_start>
+    <auto_ignore>no</auto_ignore>
+    <skip_nfs>yes</skip_nfs>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories check_all="yes" realtime="yes">/etc,/boot</directories>
+    <directories check_all="yes" realtime="yes">/bin,/sbin,/usr/bin,/usr/sbin</directories>
+    <directories check_all="yes" realtime="yes">/lib,/lib64,/usr/lib,/usr/include</directories>
+    <directories check_all="yes" realtime="yes">/root/.ssh</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+
+  </syscheck>
+
+  <rootcheck>
+	<!-- Rootcheck Configuration -->
+    <frequency>86400</frequency>
+	<skip_nfs>yes</skip_nfs>
+    <check_ports>no</check_ports>
+
+    <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
+  </rootcheck>
+
+  <!-- Active Response Configs -->
+  <command>
+    <name>host-deny</name>
+    <executable>host-deny.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>firewall-drop</name>
+    <executable>firewall-drop.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>disable-account</name>
+    <executable>disable-account.sh</executable>
+    <expect>user</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <!-- Files to monitor (localfiles) -->
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/messages</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/authlog</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/secure</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/xferlog</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/maillog</location>
+  </localfile>
+<% @logfiles.each do |logfile| -%>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location><%= logfile %></location>
+  </localfile>
+<% end -%>
+
+</ossec_config>

--- a/modules/ossec/templates/server.conf.erb
+++ b/modules/ossec/templates/server.conf.erb
@@ -1,0 +1,189 @@
+<!-- MetaCPAN OSSEC Config -->
+<ossec_config>
+  <global>
+    <email_notification><%= @email_notification ? 'yes' : 'no' %></email_notification>
+    <email_to><%= @email_to %></email_to>
+    <smtp_server><%= @smtp_server %></smtp_server>
+    <email_from><%= @email_from %></email_from>
+    <zeromq_output><%= @zeromq_output ? 'yes' : 'no' %></zeromq_output>
+    <zeromq_uri><%= @zeromq_uri %></zeromq_uri>
+  </global>
+
+  <rules>
+    <include>rules_config.xml</include>
+    <include>pam_rules.xml</include>
+    <include>sshd_rules.xml</include>
+    <include>telnetd_rules.xml</include>
+    <include>syslog_rules.xml</include>
+    <include>arpwatch_rules.xml</include>
+    <include>symantec-av_rules.xml</include>
+    <include>symantec-ws_rules.xml</include>
+    <include>pix_rules.xml</include>
+    <include>named_rules.xml</include>
+    <include>smbd_rules.xml</include>
+    <include>vsftpd_rules.xml</include>
+    <include>pure-ftpd_rules.xml</include>
+    <include>proftpd_rules.xml</include>
+    <include>ms_ftpd_rules.xml</include>
+    <include>ftpd_rules.xml</include>
+    <include>hordeimp_rules.xml</include>
+    <include>roundcube_rules.xml</include>
+    <include>wordpress_rules.xml</include>
+    <include>cimserver_rules.xml</include>
+    <include>vpopmail_rules.xml</include>
+    <include>vmpop3d_rules.xml</include>
+    <include>courier_rules.xml</include>
+    <include>web_rules.xml</include>
+    <include>web_appsec_rules.xml</include>
+    <include>apache_rules.xml</include>
+    <include>nginx_rules.xml</include>
+    <include>php_rules.xml</include>
+    <include>mysql_rules.xml</include>
+    <include>postgresql_rules.xml</include>
+    <include>ids_rules.xml</include>
+    <include>squid_rules.xml</include>
+    <include>firewall_rules.xml</include>
+    <include>apparmor_rules.xml</include>
+    <include>cisco-ios_rules.xml</include>
+    <include>netscreenfw_rules.xml</include>
+    <include>sonicwall_rules.xml</include>
+    <include>postfix_rules.xml</include>
+    <include>sendmail_rules.xml</include>
+    <include>imapd_rules.xml</include>
+    <include>mailscanner_rules.xml</include>
+    <include>dovecot_rules.xml</include>
+    <include>ms-exchange_rules.xml</include>
+    <include>racoon_rules.xml</include>
+    <include>vpn_concentrator_rules.xml</include>
+    <include>spamd_rules.xml</include>
+    <include>msauth_rules.xml</include>
+    <include>mcafee_av_rules.xml</include>
+    <include>trend-osce_rules.xml</include>
+    <include>ms-se_rules.xml</include>
+    <!-- <include>policy_rules.xml</include> -->
+    <include>zeus_rules.xml</include>
+    <include>solaris_bsm_rules.xml</include>
+    <include>vmware_rules.xml</include>
+    <include>ms_dhcp_rules.xml</include>
+    <include>asterisk_rules.xml</include>
+    <include>ossec_rules.xml</include>
+    <include>attack_rules.xml</include>
+    <include>dropbear_rules.xml</include>
+    <include>unbound_rules.xml</include>
+    <include>sysmon_rules.xml</include>
+    <include>opensmtpd_rules.xml</include>
+    <include>local_rules.xml</include>
+	<!-- MetaCPAN Specific Rules -->
+    <include>overwrite_rules.xml</include>
+  </rules>
+
+
+  <syscheck>
+    <!-- Syscheck Configuration -->
+    <frequency>86400</frequency>
+    <scan_on_start>no</scan_on_start>
+    <auto_ignore>no</auto_ignore>
+    <skip_nfs>yes</skip_nfs>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories check_all="yes" realtime="yes">/etc,/boot</directories>
+    <directories check_all="yes" realtime="yes">/bin,/sbin,/usr/bin,/usr/sbin</directories>
+    <directories check_all="yes" realtime="yes">/lib,/lib64,/usr/lib,/usr/include</directories>
+    <directories check_all="yes" realtime="yes">/root/.ssh</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+
+  </syscheck>
+
+  <rootcheck>
+	<!-- Rootcheck Configuration -->
+    <frequency>86400</frequency>
+	<skip_nfs>yes</skip_nfs>
+    <check_ports>no</check_ports>
+
+    <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
+  </rootcheck>
+
+  <global>
+    <white_list>127.0.0.1</white_list>
+    <white_list>::1</white_list>
+<% @ip_whitelist.each do |entry| -%>
+    <white_list><%= entry %></white_list>
+<% end %>
+  </global>
+
+  <remote>
+    <connection>secure</connection>
+  </remote>
+
+  <alerts>
+    <log_alert_level>1</log_alert_level>
+    <email_alert_level><%= @email_alert_level %></email_alert_level>
+  </alerts>
+
+  <command>
+    <name>host-deny</name>
+    <executable>host-deny.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>firewall-drop</name>
+    <executable>firewall-drop.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>disable-account</name>
+    <executable>disable-account.sh</executable>
+    <expect>user</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+
+  <!-- Active Response Config -->
+
+  <!-- Files to monitor (localfiles) -->
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/messages</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/authlog</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/secure</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/xferlog</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/maillog</location>
+  </localfile>
+<% @logfiles.each do |logfile| -%>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location><%= logfile %></location>
+  </localfile>
+<% end -%>
+
+</ossec_config>


### PR DESCRIPTION
This is a first step for the logging requirements.  With this in place, we'll have log correlation and security event detection, as well as File Integrity Monitoring.  This is only a first pass, so it'll need tweaks to the rules and the flow to get the alert volume down to manageable levels.  In the meantime, I've created the email aliases necessary (ossec@ and security@) and added myself.

I'll need to deploy this is the OSSEC server (bm-mc-03) first and then to the a node and see what happens.  I know @ranguard had a method to do manual Puppet deploys, but I can't remember it off-hand.  I'd like to sync up with @ranguard to deploy this, so I can make sure it goes smoothly.