### PR TITLE
actually disable fedora and debian

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -386,11 +386,11 @@ metacpan::crons::api:
         minute : 33
         hour : 3
         ensure : absent
-#    external_fedora:
-#        cmd : 'external --external_source fedora --email_to book@cpan.org'
-#        minute : 35
-#        hour : 3
-#        ensure : absent
+    external_fedora:
+        cmd : 'external --external_source fedora --email_to book@cpan.org'
+        minute : 35
+        hour : 3
+        ensure : absent
     favorite_hourly:
         cmd : 'favorite --check_missing --age 240 --queue'
         minute: '*/30'

--- a/hieradata/nodes/bm-mc-01.yaml
+++ b/hieradata/nodes/bm-mc-01.yaml
@@ -59,10 +59,10 @@ metacpan::crons::api:
       ensure : present
     external_cygwin:
       ensure : present
-    external_debian:
-      ensure : present
-    external_fedora:
-      ensure : present
+#    external_debian:
+#      ensure : present
+#    external_fedora:
+#      ensure : present
     contributor_daily:
       ensure : present
     contributor_weekly:

--- a/hieradata/nodes/lw-mc-03.yaml
+++ b/hieradata/nodes/lw-mc-03.yaml
@@ -67,8 +67,8 @@ metacpan::crons::api:
       ensure : present
     external_cygwin:
       ensure : present
-    external_debian:
-      ensure : present
+#    external_debian:
+#      ensure : present
 #    external_fedora:
 #      ensure : present
     contributor_daily:


### PR DESCRIPTION
Note: common.yaml defaults to 'absent' - if you remove it then it will not be managed so puppet will leave it as what ever state it was last before you stopped managing it.

We are running all (other than ES snapshot) jobs on both lw-mc-03 and bm-mc-01 so in a disaster they are close to being in sync.