### PR TITLE
nasty nasty, untested hack to get the init files correct again - TEST Before merge!

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -141,6 +141,7 @@ metacpan::web::starman:
       - "st.aticpan.org"
     starman_port: 5000
     starman_workers: 2
+    starman_init_template: 'starman/init.api.erb'
     vhost_extra_proxies:
       proxy_cpan_index:
           location: '/v1/cpan'

--- a/modules/metacpan/manifests/web/starman.pp
+++ b/modules/metacpan/manifests/web/starman.pp
@@ -28,6 +28,7 @@ define metacpan::web::starman (
     # starman
     $starman_port = 'UNSET',
     $starman_workers = 1,
+    $starman_init_template = 'starman/init.pl.erb',
 ) {
 
   $path = "/home/${owner}/${name}"
@@ -83,6 +84,7 @@ define metacpan::web::starman (
       root    => $path,
       port    => $starman_port,
       workers => $starman_workers,
+      init_template => $starman_init_template,
   }
 
 

--- a/modules/starman/manifests/service.pp
+++ b/modules/starman/manifests/service.pp
@@ -6,6 +6,7 @@ define starman::service (
     $service_enable = true,
     $user = hiera('metacpan::user', 'metacpan'),
     $group = hiera('metacpan::group', 'metacpan'),
+    $init_template = 'starman/init.pl.erb',
 ) {
     include perl
     include starman::config
@@ -83,7 +84,7 @@ define starman::service (
         mode    => '0755',
         owner   => 'root',
         group   => 'root',
-        content => template('starman/init.pl.erb'),
+        content => template($init_template),
         notify => Service[$service_name],
     }
 

--- a/modules/starman/templates/init.api.erb
+++ b/modules/starman/templates/init.api.erb
@@ -26,9 +26,8 @@ my %dirs = (
     pid => "$home/var/run",
     log => "$home/var/log",
 );
-my $carton    = '<%= @perlbin %>/carton';
+my $carton    = "$home/../bin/metacpan-api-carton-exec";
 my $workers   = <%= @workers %>;
-my $plack_env = '<%= @plack_env %>';
 
 my $carton_dir = "/home/${user}/carton";
 my $carton_path = "${carton_dir}/${name}";
@@ -37,14 +36,10 @@ my $carton_path = "${carton_dir}/${name}";
 $ENV{PERL_CARTON_PATH} = $carton_path;
 
 my @program_args = (
-    'exec', "${carton_path}/bin/plackup",
-    '--port'    => <%= @port %>,
+    '--', "bin/api.pl",
+    'prefork', '--proxy',
+    '--listen'    => "http://*:<%= @port %>",
     '--workers' => $workers,
-    '-E'        => $plack_env,
-    '-Ilib',
-    '-a'  => 'app.psgi',
-    '-s', => 'Gazelle',
-    '--disable-proctitle', # so we know which processes are what
 );
 
 # Puppet should be doing this with symlinks


### PR DESCRIPTION
Hi,

This basically reverts the changes on the init.pl.erb template and adds a new `init.api.erb` template just for the api, it also allows which template to use via hiera (defaulting to the old init.pl.erb one).

This is of course a nasty hack (puppet shouldn't have specific files where possible), it is also TOTALLY UNTESTED as I don't have my test env running, so please test locally first before merging

Leo