### PR TITLE
Rotate the logs on the central log server

### DIFF
--- a/modules/metacpan/files/rsyslog_server/logrotate.d/central_logger
+++ b/modules/metacpan/files/rsyslog_server/logrotate.d/central_logger
@@ -1,0 +1,15 @@
+/var/log/remote/*/*.log
+/var/log/remote/*/messages
+/var/log/remote/*/syslog
+{
+        rotate 12
+        weekly
+        missingok
+        notifempty
+        compress
+        delaycompress
+        sharedscripts
+        postrotate
+                invoke-rc.d rsyslog rotate > /dev/null
+        endscript
+}

--- a/modules/metacpan/manifests/system/rsyslog/server.pp
+++ b/modules/metacpan/manifests/system/rsyslog/server.pp
@@ -8,9 +8,9 @@ class metacpan::system::rsyslog::server(
     enable_relp               => false,
     enable_onefile            => false,
     server_dir                => '/mnt/lv-metacpan--tmp/rsyslog_server/',
+    logdir_symlink            =>  '/var/log/remote',
     custom_config             => 'metacpan/rsyslog/server-metacpan.conf.erb',
     port                      => '514',
-#    relp_port                 => '20514',
     address                   => '*',
     high_precision_timestamps => false,
     log_templates             => false,
@@ -45,6 +45,20 @@ class metacpan::system::rsyslog::server(
       content => "#!/bin/sh\n/opt/perl-$perl_version/bin/perl /opt/perl-$perl_version/bin/eris-dispatcher-stdin.pl\n",
       mode    => '0555',
       notify  =>  Service['rsyslog'];
+  }
+
+  # Handles the remote log storage and rotation
+  file {
+    # Drop a symlink somewhere that makes more sense
+    "$logdir_symlink":
+      ensure => 'link',
+      target => "$server_dir";
+    # Rotate logs
+    "/etc/logrotate.d/central_logger":
+      source => "puppet:///modules/metacpan/rsyslog_server/central_logger",
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0444',
   }
 }
 


### PR DESCRIPTION
I setup central logging, but blanked on setting up logrotate for those
logs.  The logs were also hidden on `bm-mc-03` in
`/mnt/lv-metacpan--tmp/rsyslog_server` which isn't where anyone would
look.  This also install a symlink from `/var/log/remote` to
`/mnt/lv-metacpan--tmp/rsyslog_server` to make this more obvious to
folks.