### PR TITLE
Don't auto-purge existing firewall rules

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -440,7 +440,7 @@ nginx::allowed:
   - 192.168.0.0/16
   - 127.0.0.1/32
   # local machine's IP
-  - "%{ipaddress}/32"
+  - "%{ipaddress_eth0}/32"
   # https://api.fastly.com/public-ip-list + 127.0.0.1/32
   - 103.244.50.0/24
   - 103.245.222.0/23

--- a/hieradata/nodes/lw-mc-02.yaml
+++ b/hieradata/nodes/lw-mc-02.yaml
@@ -29,4 +29,6 @@ metacpan::web::proxy:
 metacpan::web::starman:
 
   github-meets-cpan:
-    starman_port: 3000
+    git_enable: false
+    proxy_target_port: 3000
+    service_enable: false

--- a/hieradata/nodes/lw-mc-02.yaml
+++ b/hieradata/nodes/lw-mc-02.yaml
@@ -25,3 +25,8 @@ metacpan::web::proxy:
     vhost_aliases:
      - 'hound.metacpan.org'
     proxy_port:     6080
+
+metacpan::web::starman:
+
+  github-meets-cpan:
+    starman_port: 3000

--- a/hieradata/nodes/lw-mc-02.yaml
+++ b/hieradata/nodes/lw-mc-02.yaml
@@ -29,6 +29,5 @@ metacpan::web::proxy:
 metacpan::web::starman:
 
   github-meets-cpan:
-    git_enable: false
     proxy_target_port: 3000
     service_enable: false

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -6,10 +6,6 @@ File {
   mode  => '0644',
 }
 
-resources { "firewall":
-  purge => true
-}
-
 firewall { "000 accept related established rules":
   ensure  => present,
   proto   => 'all',

--- a/modules/facts/lib/facter/datacenter.rb
+++ b/modules/facts/lib/facter/datacenter.rb
@@ -1,6 +1,6 @@
 Facter.add(:datacenter) do
   setcode do
-    case Facter.value(:ipaddress)
+    case Facter.value(:ipaddress_eth0)
     when /^5\.153\.225\./
       # bm-mc-01 and bm-mc-02
       'bytemark-YO26-york'

--- a/modules/metacpan/manifests/web/starman.pp
+++ b/modules/metacpan/manifests/web/starman.pp
@@ -29,6 +29,11 @@ define metacpan::web::starman (
     $starman_port = 'UNSET',
     $starman_workers = 1,
     $starman_init_template = 'starman/init.pl.erb',
+
+    # allow overriding the nginx target
+    $proxy_target_port = $starman_port,
+    $service_enable    = true,
+
 ) {
 
   $path = "/home/${owner}/${name}"
@@ -64,7 +69,7 @@ define metacpan::web::starman (
 
   # Add all the extra proxy / config gumpf
   create_resources('metacpan_nginx::proxy', $vhost_extra_proxies, {
-    target   => "http://localhost:${starman_port}/",
+    target   => "http://localhost:${proxy_target_port}/",
     site    =>  $name,
     location => '',
   })
@@ -75,16 +80,17 @@ define metacpan::web::starman (
 
   # Setup rev-proxy to starman
   metacpan_nginx::proxy { "proxy_${name}":
-      target   => "http://localhost:${starman_port}/",
+      target   => "http://localhost:${proxy_target_port}/",
       site    => $name,
       location => '',
   }
 
   starman::service { $name:
-      root    => $path,
-      port    => $starman_port,
-      workers => $starman_workers,
-      init_template => $starman_init_template,
+      root           => $path,
+      port           => $starman_port,
+      workers        => $starman_workers,
+      init_template  => $starman_init_template,
+      service_enable => $service_enable,
   }
 
 


### PR DESCRIPTION
Disable purging of the firewall rules.. This should leave docker created rules in place and only manage it's own rules.