### PR TITLE
Revert "Convert things to using ipaddress_eth0"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -440,7 +440,7 @@ nginx::allowed:
   - 192.168.0.0/16
   - 127.0.0.1/32
   # local machine's IP
-  - "%{ipaddress_eth0}/32"
+  - "%{ipaddress}/32"
   # https://api.fastly.com/public-ip-list + 127.0.0.1/32
   - 103.244.50.0/24
   - 103.245.222.0/23

--- a/modules/facts/lib/facter/datacenter.rb
+++ b/modules/facts/lib/facter/datacenter.rb
@@ -1,6 +1,6 @@
 Facter.add(:datacenter) do
   setcode do
-    case Facter.value(:ipaddress_eth0)
+    case Facter.value(:ipaddress)
     when /^5\.153\.225\./
       # bm-mc-01 and bm-mc-02
       'bytemark-YO26-york'


### PR DESCRIPTION
This reverts commit e5cd0409ead041f44bc685ef3584a8c898bd6890.

TL;DR: Interfaces in ByteMark use `bond0`.