### PR TITLE
Add default_ipaddress fact

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -440,7 +440,7 @@ nginx::allowed:
   - 192.168.0.0/16
   - 127.0.0.1/32
   # local machine's IP
-  - "%{ipaddress}/32"
+  - "%{default_ipaddress}/32"
   # https://api.fastly.com/public-ip-list + 127.0.0.1/32
   - 103.244.50.0/24
   - 103.245.222.0/23

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -440,7 +440,7 @@ nginx::allowed:
   - 192.168.0.0/16
   - 127.0.0.1/32
   # local machine's IP
-  - "%{default_ipaddress}/32"
+  - "%{ipaddress}/32"
   # https://api.fastly.com/public-ip-list + 127.0.0.1/32
   - 103.244.50.0/24
   - 103.245.222.0/23

--- a/hieradata/datacenter/bytemark-YO26-york.yaml
+++ b/hieradata/datacenter/bytemark-YO26-york.yaml
@@ -11,6 +11,6 @@ metacpan::postgres::access_hosts:
 
 # Run on our public IP address (firewall limits access
 # to other nodes in our cluster)
-metacpan::elasticsearch::ipaddress: "%{::ipaddress}"
+metacpan::elasticsearch::ipaddress: "%{::default_ipaddress}"
 
 metacpan::rsyslog::client::log_remote: true

--- a/hieradata/datacenter/liquidweb.yaml
+++ b/hieradata/datacenter/liquidweb.yaml
@@ -11,7 +11,7 @@ metacpan::postgres::access_hosts:
 
 # Run on our public IP address (firewall limits access
 # to other nodes in our cluster)
-metacpan::elasticsearch::ipaddress: "%{::ipaddress}"
+metacpan::elasticsearch::ipaddress: "%{::default_ipaddress}"
 
 metacpan::logstash::status: 'enabled'
 

--- a/modules/facts/lib/facter/datacenter.rb
+++ b/modules/facts/lib/facter/datacenter.rb
@@ -1,17 +1,12 @@
 Facter.add(:datacenter) do
   setcode do
-    case Facter.value(:ipaddress)
-    when /^5\.153\.225\./
-      # bm-mc-01 and bm-mc-02
+    case Facter.value(:hostname)
+    when /^bm-mc-/
       'bytemark-YO26-york'
-    when /^46\.43\.35\.68/
-      # bm-mc-03
-      'bytemark-YO26-york'
-    when /^89\.16\.178\.21/
-      # bm-mc-04
-      'bytemark-YO26-york'
-    when /^50\.28\.18\./
+    when /^lw-mc-/
       'liquidweb'
+    when /^hc-mc-/
+      'hivelocity'
     else
       'development'
     end

--- a/modules/facts/lib/facter/ipaddress.rb
+++ b/modules/facts/lib/facter/ipaddress.rb
@@ -1,0 +1,40 @@
+require 'facter'
+require 'facter/core/execution'
+
+
+if File.exist? '/sbin/ip'
+  interfaces = Facter::Core::Execution.exec('/sbin/ip route show')
+  default_interface = nil
+  ipaddress = nil
+
+  if interfaces
+    interfaces.each do |inf|
+      if inf.match(/^default/)
+        default_interface = inf.split()[-1]
+      end
+    end
+  end
+
+  if default_interface
+    lines = Facter::Core::Execution.exec("/sbin/ip addr show dev #{default_interface}")
+    lines.each do |line|
+      line.strip!
+
+      if line.match(/^inet .*#{default_interface}/)
+        ipaddress = line.split()[1].split('/')[0]
+      end
+    end
+  end
+
+  Facter.add("default_interface") do
+    setcode do
+      default_interface
+    end
+  end
+
+  Facter.add("default_ipaddress") do
+    setcode do
+      ipaddress
+    end
+  end
+end

--- a/modules/facts/lib/facter/ipaddress.rb
+++ b/modules/facts/lib/facter/ipaddress.rb
@@ -10,7 +10,7 @@ if File.exist? '/sbin/ip'
   if interfaces
       interfaces.split(/\n+/).each do |inf|
       if inf.match(/^default/)
-        default_interface = inf.split()[-1]
+        default_interface = inf.match(/dev (\w+)/).captures[0]
       end
     end
   end

--- a/modules/facts/lib/facter/ipaddress.rb
+++ b/modules/facts/lib/facter/ipaddress.rb
@@ -1,16 +1,8 @@
-begin
-    # facter version 2 needs these loads
-    require 'facter'
-    require 'facter/core/execution'
-rescue LoadError => e
-    # No big defal, facter version 3 autloads these things differently
-end
-
+default_interface = nil
+ipaddress = nil
 
 if File.exist? '/sbin/ip'
   interfaces = Facter::Core::Execution.exec('/sbin/ip route show')
-  default_interface = nil
-  ipaddress = nil
 
   if interfaces
       interfaces.split(/\n+/).each do |inf|
@@ -31,15 +23,16 @@ if File.exist? '/sbin/ip'
     end
   end
 
-  Facter.add("default_interface") do
-    setcode do
-      default_interface
-    end
-  end
+end
 
-  Facter.add("default_ipaddress") do
-    setcode do
-      ipaddress
-    end
+Facter.add("default_interface") do
+  setcode do
+    default_interface
+  end
+end
+
+Facter.add("default_ipaddress") do
+  setcode do
+    ipaddress
   end
 end

--- a/modules/facts/lib/facter/ipaddress.rb
+++ b/modules/facts/lib/facter/ipaddress.rb
@@ -8,7 +8,7 @@ if File.exist? '/sbin/ip'
   ipaddress = nil
 
   if interfaces
-    interfaces.each do |inf|
+      interfaces.split(/\n+/).each do |inf|
       if inf.match(/^default/)
         default_interface = inf.split()[-1]
       end
@@ -17,7 +17,7 @@ if File.exist? '/sbin/ip'
 
   if default_interface
     lines = Facter::Core::Execution.exec("/sbin/ip addr show dev #{default_interface}")
-    lines.each do |line|
+    lines.split(/\n+/).each do |line|
       line.strip!
 
       if line.match(/^inet .*#{default_interface}/)

--- a/modules/facts/lib/facter/ipaddress.rb
+++ b/modules/facts/lib/facter/ipaddress.rb
@@ -1,38 +1,11 @@
-default_interface = nil
-ipaddress = nil
-
-if File.exist? '/sbin/ip'
-  interfaces = Facter::Core::Execution.exec('/sbin/ip route show')
-
-  if interfaces
-      interfaces.split(/\n+/).each do |inf|
-      if inf.match(/^default/)
-        default_interface = inf.match(/dev (\w+)/).captures[0]
-      end
-    end
-  end
-
-  if default_interface
-    lines = Facter::Core::Execution.exec("/sbin/ip addr show dev #{default_interface}")
-    lines.split(/\n+/).each do |line|
-      line.strip!
-
-      if line.match(/^inet .*#{default_interface}/)
-        ipaddress = line.split()[1].split('/')[0]
-      end
-    end
-  end
-
-end
-
-Facter.add("default_interface") do
-  setcode do
-    default_interface
-  end
-end
-
 Facter.add("default_ipaddress") do
   setcode do
-    ipaddress
+    if Facter.value('ipaddress_eth0')
+      Facter.value('ipaddress_eth0')
+    elsif Facter.value('ipaddress_bond0')
+      Facter.value('ipaddress_bond0')
+    else
+      Facter.value('ipaddress')
+    end
   end
 end

--- a/modules/facts/lib/facter/ipaddress.rb
+++ b/modules/facts/lib/facter/ipaddress.rb
@@ -1,5 +1,10 @@
-require 'facter'
-require 'facter/core/execution'
+begin
+    # facter version 2 needs these loads
+    require 'facter'
+    require 'facter/core/execution'
+rescue LoadError => e
+    # No big defal, facter version 3 autloads these things differently
+end
 
 
 if File.exist? '/sbin/ip'

--- a/modules/metacpan/manifests/system/rsyslog/server.pp
+++ b/modules/metacpan/manifests/system/rsyslog/server.pp
@@ -55,7 +55,7 @@ class metacpan::system::rsyslog::server(
       target => "$server_dir";
     # Rotate logs
     "/etc/logrotate.d/central_logger":
-      source => "puppet:///modules/metacpan/rsyslog_server/central_logger",
+      source => "puppet:///modules/metacpan/rsyslog_server/logrotate.d/central_logger",
       owner  => 'root',
       group  => 'root',
       mode   => '0444',

--- a/run.sh
+++ b/run.sh
@@ -38,5 +38,7 @@ fi
 
 # Stop complaints on vagrant
 mkdir -p private
-
+# Ugly hack to make a local class apply the facts
+export FACTERLIB=/etc/puppet/modules/facts/lib/facter
+# Run Puppet
 puppet apply --modulepath /etc/puppet/contrib-modules:/etc/puppet/modules --show_diff --certname=$CERTNAME manifests/site.pp $@


### PR DESCRIPTION
There's a bug in our version of `facter` that causes `docker0`
interfaces to override the routable public IP as the `ipaddress` fact.
This code comes from [the PuppetLabs bug
report](https://tickets.puppetlabs.com/browse/FACT-380) describing the
problem.  This is fixed in facter 3, but we are running v2.4.6.