### PR TITLE
Cleanup fedora cron references (logic was removed from api)

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -380,11 +380,6 @@ metacpan::crons::api:
         minute : 33
         hour : 3
         ensure : absent
-    external_fedora:
-        cmd : 'external --external_source fedora --email_to book@cpan.org'
-        minute : 35
-        hour : 3
-        ensure : absent
     favorite_hourly:
         cmd : 'favorite --check_missing --age 240 --queue'
         minute: '*/30'

--- a/hieradata/nodes/bm-mc-01.yaml
+++ b/hieradata/nodes/bm-mc-01.yaml
@@ -57,8 +57,6 @@ metacpan::crons::api:
       ensure : present
 #    external_debian:
 #      ensure : present
-#    external_fedora:
-#      ensure : present
     contributor_daily:
       ensure : present
     contributor_weekly:

--- a/hieradata/nodes/lw-mc-03.yaml
+++ b/hieradata/nodes/lw-mc-03.yaml
@@ -60,8 +60,6 @@ metacpan::crons::api:
       ensure : present
 #    external_debian:
 #      ensure : present
-#    external_fedora:
-#      ensure : present
     contributor_daily:
       ensure : present
     contributor_weekly:


### PR DESCRIPTION
Since we cleaned out the logic in api, this is cleaning out the references to the crons.