### PR TITLE
fix default_ipaddress for Liquid web data center hosts

### DIFF
--- a/modules/facts/lib/facter/ipaddress.rb
+++ b/modules/facts/lib/facter/ipaddress.rb
@@ -4,6 +4,8 @@ Facter.add("default_ipaddress") do
       Facter.value('ipaddress_eth0')
     elsif Facter.value('ipaddress_bond0')
       Facter.value('ipaddress_bond0')
+    elsif Facter.value('ipaddress_eth2')
+      Facter.value('ipaddress_eth2')
     else
       Facter.value('ipaddress')
     end


### PR DESCRIPTION
because the Internet interface is eth2 and docker0 took precedence