### PR TITLE
remove dead or moved services

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -225,18 +225,6 @@ metacpan::crons::general:
       minute : 22
       ensure : absent
 
-    metacpan_sitemaps:
-      cmd : "/home/%{hiera('metacpan::user')}/bin/metacpan-web-carton-exec bin/generate_sitemap.pl"
-      hour : 2
-      minute : 0
-      ensure : absent
-
-    github-meets-cpan:
-      cmd : "/home/%{hiera('metacpan::user')}/bin/github-meets-cpan-carton-exec cron/update.pl"
-      minute : 20
-      hour : 1
-      ensure : absent
-
 # NOTE: set to `absent` here - turn on in the node
 metacpan::crons::api:
     # Remvoe author - now in wrapper script in general

--- a/hieradata/env/production.yaml
+++ b/hieradata/env/production.yaml
@@ -35,29 +35,6 @@ metacpan::web::starman:
     git_enable: true
     starman_workers: 14
 
-  api-v0-shim:
-    git_source: 'https://github.com/metacpan/metacpan-api-v0-shim.git'
-    git_revision: 'master'
-    vhost_bare: true
-    vhost_aliases:
-      - 'api-v0-shim.metacpan.org'
-    starman_port: 5003
-    git_enable: true
-    starman_workers: 2
-
-  github-meets-cpan:
-    git_enable: true
-    starman_workers: 1
-    git_source: 'https://github.com/metacpan/github-meets-cpan.git'
-    git_revision: 'master'
-    vhost_bare: true
-    vhost_aliases:
-      - 'gh.metacpan.org'
-      - "gh.lo.metacpan.org"
-      - "gh.%{hostname}.metacpan.org"
-    starman_port: 5002
-    starman_workers: 1
-
   sco-redirect:
     git_enable: true
     starman_workers: 10

--- a/hieradata/nodes/lw-mc-02.yaml
+++ b/hieradata/nodes/lw-mc-02.yaml
@@ -10,10 +10,6 @@ minion_queue::service::enable: true
 
 
 metacpan::crons::general:
-    github-meets-cpan:
-      ensure : present
-
-metacpan::crons::general:
     metacpan_sitemaps:
       minute : 25
 
@@ -26,8 +22,3 @@ metacpan::web::proxy:
      - 'hound.metacpan.org'
     proxy_port:     6080
 
-metacpan::web::starman:
-
-  github-meets-cpan:
-    proxy_target_port: 3000
-    service_enable: false

--- a/hieradata/nodes/metacpan-dev.yaml
+++ b/hieradata/nodes/metacpan-dev.yaml
@@ -40,14 +40,8 @@ metacpan::elasticsearch::env: 'dev'
 
 # Open up ports for development
 metacpan::fw_ports:
-  metacpan_web:
-    port: 5001
-    source: '0.0.0.0/0'
   metacpan_api:
     port: 5000
-    source: '0.0.0.0/0'
-  github-meets-cpan:
-    port: 5002
     source: '0.0.0.0/0'
 
 starman::config::plack_env: development

--- a/modules/metacpan/manifests/web.pp
+++ b/modules/metacpan/manifests/web.pp
@@ -4,10 +4,4 @@ class metacpan::web(
 		$group = hiera('metacpan::group', 'metacpan'),
 ) {
 
-	file { "/home/${user}/metacpan-web/root/static/sitemaps":
-			ensure => directory,
-			owner => $user,
-			group => $group,
-	}
-
 }

--- a/modules/metacpan/manifests/web/production.pp
+++ b/modules/metacpan/manifests/web/production.pp
@@ -21,14 +21,4 @@ class metacpan::web::production(
       notify => Starman::Service['metacpan-api'],
   }
 
-  file { "/home/${user}/github-meets-cpan/environment.json":
-      ensure => file,
-      owner => $user,
-      group => $group,
-      source => "puppet:///private/github-meets-cpan/environment.json",
-      require => Metacpan::Gitrepo['gitrepo_github-meets-cpan'], # after repo created
-      notify => Starman::Service['github-meets-cpan'],
-  }
-
-
 }


### PR DESCRIPTION
Remove the remains of metacpan-web, as well as github-meets-cpan and api-v0-shim. They have been removed or moved to kubernetes.