### PR TITLE
run the metacpan-api app.psgi, not the api.pl

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -125,7 +125,7 @@ metacpan::web::starman:
       - "st.aticpan.org"
     starman_port: 5000
     starman_workers: 2
-    starman_init_template: 'starman/init.api.erb'
+    starman_init_template: 'starman/init.pl.erb'
     vhost_extra_proxies:
       proxy_cpan_index:
           location: '/v1/cpan'

--- a/hieradata/env/production.yaml
+++ b/hieradata/env/production.yaml
@@ -31,7 +31,7 @@ metacpan::web::starman:
 
   metacpan-api:
     git_enable: true
-    starman_workers: 14
+    starman_workers: 30
 
   sco-redirect:
     git_enable: true


### PR DESCRIPTION
Currently, metacpan-api has an app.psgi for the Catalyst app. This has most of the end points. There is also an api.pl script which runs Mojolicious. This hosts a Minion admin interface, a few end points which are duplicates of the Catalyst end points, and mounts the app.psgi to handle everything else.

This setup uses the Mojolicious MountPSGI plugin. This plugin is rather limited and has some issues. It ends up loading the PSGI app the first time it is requested. This means in a prefork setup, none of the memory is shared. This is wasteful, but also means creating worker processes is very slow. And if it is slow enough, the worker won't respond to the heartbeat check, and the parent process will kill it before it is even ready.

The problems with MountPSGI could be fixed, but the Mojolicious app is also just adding complexity without providing any real value in its current state. The end points it provides are duplicates.

We aren't using the Minion integration to dispatch tasks anywhere in the API. And its admin interface doesn't really belong in the same service as the API server.

Simplify the way metacpan-api is hosted by just running the Catalyst app. This avoids the problems with the MountPSGI plugin. Replacing the Minion admin interface is a task left for a different time.

Using Mojolicous in the future would be reasonable, but it should be done as a proper conversion.