### PR TITLE
update codeql and ignore contrib code

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,20 +12,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          # We must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head.
-          fetch-depth: 2
-
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
+          # If this run was triggered by a pull request event, then checkout
+          # the head of the pull request instead of the merge commit.
+          ref: ${{ ( github.event_name == 'pull_request' && github.event.pull_request.head.sha ) || github.context.ref }}
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
+        with:
+          config: |
+            paths-ignore:
+              - contrib-modules
         # Override language selection by uncommenting this and choosing your
         # languages with:
         #   languages: go, javascript, csharp, python, cpp, java
@@ -34,7 +33,7 @@ jobs:
       # Java). If this step fails, then you should remove it and run the build
       # manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -48,4 +47,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Update the CodeQL workflow to use newer versions of the actions. Configure it to directly check out the correct commit. And configure it to ignore the contrib-modules directory.