### PR TITLE
Temporarily switch to a new CPAN rsync host

### DIFF
--- a/modules/rrrclient/manifests/cron.pp
+++ b/modules/rrrclient/manifests/cron.pp
@@ -29,7 +29,7 @@ define rrrclient::cron(
       'metacpan_daily_rsync':
           user        => $user,
           # NOTE: No "--delete" arg since we're also a backpan.
-          command     => "/usr/bin/rsync -a cpan-rsync.perl.org::CPAN ${cpan_mirror}",
+          command     => "/usr/bin/rsync -a 23.29.118.28::PAUSE ${cpan_mirror}",
           hour        => '23',
           minute      => '13',
           ensure      => $ensure;

--- a/modules/rrrclient/templates/init.erb
+++ b/modules/rrrclient/templates/init.erb
@@ -30,7 +30,7 @@ test -x $BIN || { echo "$BIN not installed";
 case "$1" in
     start)
 	echo -n "Starting <%= @filename %> "
-        start-stop-daemon --start --background -c <%= @owner %> -m -p <%= @pid_file %> --startas <%= @bin %> -- --source cpan-rsync.perl.org::CPAN/RECENT.recent --target <%= @cpan_mirror %> --skip-deletes
+        start-stop-daemon --start --background -c <%= @owner %> -m -p <%= @pid_file %> --startas <%= @bin %> -- --source 23.29.118.28::PAUSE/RECENT.recent --target <%= @cpan_mirror %> --skip-deletes
 	;;
     stop)
 	echo -n "Shutting down <%= @filename %> "


### PR DESCRIPTION
We will revert this once the main mirror is back online, so we don't
need to use a variable for the hostname in this case.
